### PR TITLE
Implement Baked BlockEntity rendering for Text Blocks

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/block/entity/TextBlockEntity.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/entity/TextBlockEntity.java
@@ -1,6 +1,7 @@
 package dev.hephaestus.glowcase.block.entity;
 
 import dev.hephaestus.glowcase.Glowcase;
+import dev.hephaestus.glowcase.client.render.block.entity.BakedBlockEntityRenderer;
 import net.fabricmc.fabric.api.block.entity.BlockEntityClientSerializable;
 import net.fabricmc.fabric.api.network.PacketContext;
 import net.minecraft.block.BlockState;
@@ -26,6 +27,7 @@ public class TextBlockEntity extends BlockEntity implements BlockEntityClientSer
 	public ShadowType shadowType = ShadowType.DROP;
 	public float scale = 1F;
 	public int color = 0xFFFFFF;
+	public boolean renderDirty = true;
 
 	public TextBlockEntity() {
 		super(Glowcase.TEXT_BLOCK_ENTITY);
@@ -69,6 +71,7 @@ public class TextBlockEntity extends BlockEntity implements BlockEntityClientSer
 		for (Tag line : lines) {
 			this.lines.add(Text.Serializer.fromJson(line.asString()));
 		}
+		this.renderDirty = true;
 	}
 
 	@Override
@@ -124,5 +127,13 @@ public class TextBlockEntity extends BlockEntity implements BlockEntityClientSer
 
 	public enum ShadowType {
 		DROP, PLATE, NONE
+	}
+
+	@SuppressWarnings({"MethodCallSideOnly", "VariableUseSideOnly"})
+	@Override
+	public void markRemoved() {
+		if (world != null && world.isClient) {
+			BakedBlockEntityRenderer.VertexBufferManager.INSTANCE.invalidate(getPos());
+		}
 	}
 }

--- a/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/BakedBlockEntityRenderer.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/BakedBlockEntityRenderer.java
@@ -1,0 +1,306 @@
+package dev.hephaestus.glowcase.client.render.block.entity;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
+import it.unimi.dsi.fastutil.objects.ObjectArraySet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.client.gl.VertexBuffer;
+import net.minecraft.client.render.*;
+import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
+import net.minecraft.client.render.block.entity.BlockEntityRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+
+import java.util.*;
+
+public abstract class BakedBlockEntityRenderer<T extends BlockEntity> extends BlockEntityRenderer<T> {
+	public BakedBlockEntityRenderer(BlockEntityRenderDispatcher dispatcher) {
+		super(dispatcher);
+	}
+
+	/**
+	 * Handles invalidation and passing of rendered vertices to the baking system.
+	 * Override renderBaked and renderUnbaked instead of this method.
+	 */
+	@Override
+	public final void render(T entity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
+		renderUnbaked(entity, tickDelta, matrices, vertexConsumers, light, overlay);
+		VertexBufferManager.INSTANCE.activateRegion(entity.getPos());
+	}
+
+	/**
+	 * Render vertices to be baked into the render region. This method will be called every time the render region is rebuilt - so
+	 * you should only render vertices that don't move here. You can call invalidateSelf or VertexBufferManager.invalidate to
+	 * cause the render region to be rebuilt, but do not call this too frequently as it will affect performance.
+	 *
+	 * You must use the provided VertexConsumerProvider and MatrixStack to render your vertices - any use of Tessellator
+	 * or RenderSystem here will not work. If you need custom rendering settings, you can use a custom RenderLayer.
+	 */
+	public abstract void renderBaked(T entity, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay);
+
+	/**
+	 * Render vertices immediately. This works exactly the same way as a normal BER render method, and can be used for dynamic
+	 * rendering that changes every frame. In this method you can also check for render invalidation and call invalidateSelf
+	 * as appropriate.
+	 */
+	public abstract void renderUnbaked(T entity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay);
+
+	/**
+	 * Causes the render region containing this BlockEntity to be rebuilt -
+	 * do not call this too frequently as it will affect performance.
+	 * An invalidation will not immediately cause the next frame to contain an updated view (and call to renderBaked)
+	 * as all render region rebuilds must call every BER that is to be rendered, otherwise they will be missing from the
+	 * vertex buffer.
+	 */
+	public void invalidateSelf(T entity) {
+		VertexBufferManager.INSTANCE.invalidate(entity.getPos());
+	}
+
+	private static class RenderRegionPos {
+		private final int x;
+		private final int z;
+
+		public RenderRegionPos(BlockPos pos) {
+			this.x = pos.getX() >> VertexBufferManager.REGION_SHIFT;
+			this.z = pos.getZ() >> VertexBufferManager.REGION_SHIFT;
+		}
+
+		public RenderRegionPos(int x, int z) {
+			this.x = x;
+			this.z = z;
+		}
+
+		public BlockPos getOrigin() {
+			return new BlockPos(x << VertexBufferManager.REGION_SHIFT, 0, z << VertexBufferManager.REGION_SHIFT);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			RenderRegionPos that = (RenderRegionPos) o;
+			return x == that.x &&
+				z == that.z;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(x, z);
+		}
+	}
+
+	// TODO: lazy init?
+	public static class VertexBufferManager {
+		public static final VertexBufferManager INSTANCE = new VertexBufferManager();
+
+		// 2x2 chunks size for regions
+		public static final int REGION_FROMCHUNK_SHIFT = 1;
+		public static final int REGION_SHIFT = 4 + REGION_FROMCHUNK_SHIFT;
+		public static final int MAX_XZ_IN_REG = (16 << REGION_FROMCHUNK_SHIFT) - 1;
+		public static final int VIEW_RADIUS = 3;
+
+		private final Map<RenderRegionPos, RegionBuffer> cachedRegions = new HashMap<>();
+
+		private final ObjectSet<RenderRegionPos> invalidRegions = new ObjectArraySet<>();
+		private final Map<RenderRegionPos, RegionBuilder> rebuilders = new Object2ObjectArrayMap<>();
+
+		private ClientWorld currWorld = null;
+
+		private static class RegionBuffer {
+			private final Map<RenderLayer, VertexBuffer> layerBuffers = new Object2ObjectArrayMap<>();
+			public final BlockPos origin;
+
+			public RegionBuffer(RenderRegionPos region) {
+				origin = region.getOrigin();
+			}
+
+			public boolean hasLayer(RenderLayer rl) {
+				return layerBuffers.containsKey(rl);
+			}
+
+			public void render(RenderLayer rl, MatrixStack matrices) {
+				VertexBuffer buf = layerBuffers.get(rl);
+				buf.bind();
+				rl.getVertexFormat().startDrawing(0L);
+				buf.draw(matrices.peek().getModel(), rl.getDrawMode());
+			}
+
+			public void rebuild(RenderLayer rl, BufferBuilder newBuf) {
+				VertexBuffer buf = layerBuffers.computeIfAbsent(rl, renderLayer -> new VertexBuffer(rl.getVertexFormat()));
+				// TODO: check translucency of RenderLayer first?
+				newBuf.sortQuads(0, 0, 0);
+				newBuf.end();
+				buf.upload(newBuf);
+			}
+
+			public void deallocate() {
+				for (VertexBuffer buf : layerBuffers.values()) {
+					buf.close();
+				}
+			}
+
+			public void removeUnusedLayers(Set<RenderLayer> usedLayers) {
+				Iterator<RenderLayer> iter = layerBuffers.keySet().iterator();
+				while (iter.hasNext()) {
+					RenderLayer rl = iter.next();
+					if (!usedLayers.contains(rl)) {
+						layerBuffers.get(rl).close();
+						iter.remove();
+					}
+				}
+			}
+
+			public Set<RenderLayer> getAllLayers() {
+				return layerBuffers.keySet();
+			}
+		}
+
+		private static class RegionBuilder implements VertexConsumerProvider, Iterable<Map.Entry<RenderLayer, BufferBuilder>> {
+			private final Map<RenderLayer, BufferBuilder> bufs = new Object2ObjectArrayMap<>();
+
+			private <E extends BlockEntity> void render(E blockEntity) {
+				BlockEntityRenderer<E> ber = BlockEntityRenderDispatcher.INSTANCE.get(blockEntity);
+				if (ber instanceof BakedBlockEntityRenderer) {
+					MatrixStack bakeStack = new MatrixStack();
+					BlockPos pos = blockEntity.getPos();
+					bakeStack.translate(pos.getX() & VertexBufferManager.MAX_XZ_IN_REG, pos.getY(), pos.getZ() & VertexBufferManager.MAX_XZ_IN_REG);
+					World world = blockEntity.getWorld();
+					int light;
+					if (world != null) {
+						light = WorldRenderer.getLightmapCoordinates(world, blockEntity.getPos());
+					} else {
+						light = 15728880;
+					}
+					((BakedBlockEntityRenderer<E>) ber).renderBaked(blockEntity, bakeStack, this, light, OverlayTexture.DEFAULT_UV);
+				}
+			}
+
+			public void build(List<BlockEntity> blockEntities) {
+				for (BlockEntity be : blockEntities) {
+					render(be);
+				}
+			}
+
+			@Override
+			public VertexConsumer getBuffer(RenderLayer layer) {
+				return bufs.computeIfAbsent(layer, l -> {
+					BufferBuilder buf = new BufferBuilder(l.getExpectedBufferSize());
+					buf.begin(l.getDrawMode(), l.getVertexFormat());
+					return buf;
+				});
+			}
+
+			public Iterator<Map.Entry<RenderLayer, BufferBuilder>> iterator() {
+				return bufs.entrySet().iterator();
+			}
+		}
+
+		public void invalidate(BlockPos pos) {
+			// Mark a region as invalid. After the current set of rebuilding regions (invalid regions from the last frame) have been
+			// built, a RegionBuilder will be created for this region and passed to all BERs to render to
+			invalidRegions.add(new RenderRegionPos(pos));
+		}
+
+		// TODO: move chunk baking off-thread?
+
+		private boolean isVisiblePos(RenderRegionPos rrp, RenderRegionPos center) {
+			return Math.abs(rrp.x - center.x) <= VIEW_RADIUS && Math.abs(rrp.z - center.z) <= VIEW_RADIUS;
+		}
+
+		public void render(MatrixStack matrices, Camera camera) {
+			Vec3d vec3d = camera.getPos();
+			double camX = vec3d.getX();
+			double camY = vec3d.getY();
+			double camZ = vec3d.getZ();
+			RenderRegionPos centerRegion = new RenderRegionPos((int)camX >> REGION_SHIFT, (int)camZ >> REGION_SHIFT);
+
+			// Iterate over all RegionBuilders, render and upload to RegionBuffers
+			Set<RenderLayer> usedRenderLayers = new ObjectArraySet<>();
+			List<BlockEntity> blockEntities = new ArrayList<>();
+			for (Map.Entry<RenderRegionPos, RegionBuilder> entryBuilder : rebuilders.entrySet()) {
+				RenderRegionPos rrp = entryBuilder.getKey();
+				if (isVisiblePos(rrp, centerRegion)) {
+					// For the current region, rebuild each render layer using the buffer builders
+					// Find all block entities in this region
+					if (currWorld == null) {
+						break;
+					}
+					for (int chunkX = rrp.x << REGION_FROMCHUNK_SHIFT; chunkX < (rrp.x + 1) << REGION_FROMCHUNK_SHIFT; chunkX++) {
+						for (int chunkZ = rrp.z << REGION_FROMCHUNK_SHIFT; chunkZ < (rrp.z + 1) << REGION_FROMCHUNK_SHIFT; chunkZ++) {
+							blockEntities.addAll(currWorld.getChunk(chunkX, chunkZ).getBlockEntities().values());
+						}
+					}
+					entryBuilder.getValue().build(blockEntities);
+					blockEntities.clear();
+					RegionBuffer buf = cachedRegions.computeIfAbsent(entryBuilder.getKey(), RegionBuffer::new);
+					for (Map.Entry<RenderLayer, BufferBuilder> layerBuilder : entryBuilder.getValue()) {
+						buf.rebuild(layerBuilder.getKey(), layerBuilder.getValue());
+						usedRenderLayers.add(layerBuilder.getKey());
+					}
+					buf.removeUnusedLayers(usedRenderLayers);
+					usedRenderLayers.clear();
+				}
+			}
+			// End the current region rebuild pass, make builders for invalidated regions
+			// TODO: move this phase - we don't need to wait anymore
+			// TODO: reuse bufferbuilders?
+			rebuilders.clear();
+			for (RenderRegionPos rrp : invalidRegions) {
+				rebuilders.put(rrp, new RegionBuilder());
+			}
+			invalidRegions.clear();
+
+			// TODO: reuse VBOs?
+			// Get a list of layers, remove unused RegionBuffers
+			Set<RenderLayer> renderLayers = new ObjectArraySet<>();
+			Iterator<Map.Entry<RenderRegionPos, RegionBuffer>> iterBuffers = cachedRegions.entrySet().iterator();
+			while (iterBuffers.hasNext()) {
+				Map.Entry<RenderRegionPos, RegionBuffer> entryBuffer = iterBuffers.next();
+				if (isVisiblePos(entryBuffer.getKey(), centerRegion)) {
+					renderLayers.addAll(entryBuffer.getValue().getAllLayers());
+				} else {
+					entryBuffer.getValue().deallocate();
+					iterBuffers.remove();
+				}
+			}
+
+			// Iterate over all RegionBuffers, render them
+			for (RenderLayer layer : renderLayers) {
+				layer.startDrawing();
+				for (RegionBuffer cb : cachedRegions.values()) {
+					if (cb.hasLayer(layer)) {
+						BlockPos origin = cb.origin;
+						matrices.push();
+						matrices.translate(origin.getX() - camX, origin.getY() - camY, origin.getZ() - camZ);
+						cb.render(layer, matrices);
+						matrices.pop();
+					}
+				}
+				VertexBuffer.unbind();
+				layer.getVertexFormat().endDrawing();
+				layer.endDrawing();
+			}
+		}
+
+		public void activateRegion(BlockPos pos) {
+			RenderRegionPos rrp = new RenderRegionPos(pos);
+			if (!cachedRegions.containsKey(rrp)) {
+				rebuilders.put(rrp, new RegionBuilder());
+			}
+		}
+
+		public void setWorld(ClientWorld world) {
+			// Reset everything
+			for (RegionBuffer buf : cachedRegions.values()) {
+				buf.deallocate();
+			}
+			cachedRegions.clear();
+			invalidRegions.clear();
+			rebuilders.clear();
+			currWorld = world;
+		}
+	}
+}

--- a/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/TextBlockEntityRenderer.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/TextBlockEntityRenderer.java
@@ -1,26 +1,30 @@
 package dev.hephaestus.glowcase.client.render.block.entity;
 
+import com.mojang.blaze3d.systems.RenderSystem;
 import dev.hephaestus.glowcase.block.entity.TextBlockEntity;
-import net.minecraft.block.SignBlock;
 import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.DrawableHelper;
-import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.*;
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
-import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.state.property.Properties;
-import net.minecraft.text.Text;
-import net.minecraft.util.math.Direction;
-import net.minecraft.util.math.Quaternion;
+import net.minecraft.util.math.Matrix4f;
 
-public class TextBlockEntityRenderer extends BlockEntityRenderer<TextBlockEntity> {
+public class TextBlockEntityRenderer extends BakedBlockEntityRenderer<TextBlockEntity> {
 	public TextBlockEntityRenderer(BlockEntityRenderDispatcher dispatcher) {
 		super(dispatcher);
 	}
 
 	@Override
-	public void render(TextBlockEntity blockEntity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
+	public void renderUnbaked(TextBlockEntity entity, float tickDelta, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
+		if (entity.renderDirty) {
+			entity.renderDirty = false;
+			invalidateSelf(entity);
+		}
+	}
+
+	@Override
+	public void renderBaked(TextBlockEntity blockEntity, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {
 		matrices.push();
 		matrices.translate(0.5D, 0.5D, 0.5D);
 
@@ -58,18 +62,58 @@ public class TextBlockEntityRenderer extends BlockEntityRenderer<TextBlockEntity
 			matrices.translate(dX, 0, 0);
 
 			if (blockEntity.shadowType == TextBlockEntity.ShadowType.PLATE && width > 0) {
-				DrawableHelper.fill(matrices, -5, i * 12 - 2, (int) width + 5, (i + 1) * 12 - 2, 0x44000000);
+				matrices.translate(0, 0, -0.005D);
+				drawFillRect(matrices, vertexConsumers, (int) width + 5, (i + 1) * 12 - 2, -5, i * 12 - 2, 0x44000000);
+				matrices.translate(0, 0, 0.005D);
 			}
 
 			if (blockEntity.shadowType == TextBlockEntity.ShadowType.DROP) {
-				textRenderer.drawWithShadow(matrices, blockEntity.lines.get(i), 0, i * 12, blockEntity.color);
+				textRenderer.draw(blockEntity.lines.get(i), 0, i * 12, blockEntity.color, false, matrices.peek().getModel(), vertexConsumers, false, 0, 15728880);
+				// Don't use the vanilla shadow rendering - it breaks when you try to use it in 3D
+				int red = (blockEntity.color >> 24 & 255) / 4;
+				int green = (blockEntity.color >> 16 & 255) / 4;
+				int blue = (blockEntity.color >> 8 & 255) / 4;
+				int alpha = blockEntity.color & 255;
+				int shadowColor = (red << 24) & (green << 16) & (blue << 8) & alpha;
+				matrices.translate(0, 0, -0.005D);
+				textRenderer.draw(blockEntity.lines.get(i), 1, (i * 12) + 1, shadowColor, false, matrices.peek().getModel(), vertexConsumers, false, 0, 15728880);
 			} else {
-				textRenderer.draw(matrices, blockEntity.lines.get(i), 0, i * 12, blockEntity.color);
+				textRenderer.draw(blockEntity.lines.get(i), 0, i * 12, blockEntity.color, false, matrices.peek().getModel(), vertexConsumers, false, 0, 15728880);
 			}
 
 			matrices.pop();
 		}
 
 		matrices.pop();
+	}
+
+	// Use a custom render layer to render the text plate - mimics DrawableHelper's RenderSystem calls
+	// TODO: This causes issues with transparency - not sure if these can be fixed?
+	private final RenderLayer plateRenderLayer = RenderLayer.of("glowcase_text_plate", VertexFormats.POSITION_COLOR,
+		7, 256, true, true, RenderLayer.MultiPhaseParameters.builder()
+			// Use no texture
+			.texture(new RenderPhase.Texture())
+			.transparency(new RenderPhase.Transparency("glowcase_defaultblendfunc", () -> {
+				RenderSystem.enableBlend();
+				RenderSystem.defaultBlendFunc();
+			}, RenderSystem::disableBlend))
+			.build(false));
+
+	@SuppressWarnings("SameParameterValue")
+	private void drawFillRect(MatrixStack matrices, VertexConsumerProvider vcp, int x1, int y1, int x2, int y2, int color) {
+		float red = (float)(color >> 16 & 255) / 255.0F;
+		float green = (float)(color >> 8 & 255) / 255.0F;
+		float blue = (float)(color & 255) / 255.0F;
+		float alpha = (float)(color >> 24 & 255) / 255.0F;
+		VertexConsumer consumer = vcp.getBuffer(plateRenderLayer);
+		Matrix4f matrix = matrices.peek().getModel();
+		consumer.vertex(matrix, x1, y2, 0.0f)
+			.color(red, green, blue, alpha).next();
+		consumer.vertex(matrix, x2, y2, 0.0f)
+			.color(red, green, blue, alpha).next();
+		consumer.vertex(matrix, x2, y1, 0.0f)
+			.color(red, green, blue, alpha).next();
+		consumer.vertex(matrix, x1, y1, 0.0f)
+			.color(red, green, blue, alpha).next();
 	}
 }

--- a/src/main/java/dev/hephaestus/glowcase/mixin/client/render/ber/WorldRendererMixin.java
+++ b/src/main/java/dev/hephaestus/glowcase/mixin/client/render/ber/WorldRendererMixin.java
@@ -1,0 +1,41 @@
+package dev.hephaestus.glowcase.mixin.client.render.ber;
+
+import dev.hephaestus.glowcase.client.render.block.entity.BakedBlockEntityRenderer;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.render.Camera;
+import net.minecraft.client.render.GameRenderer;
+import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.math.Matrix4f;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Environment(EnvType.CLIENT)
+@Mixin(WorldRenderer.class)
+public class WorldRendererMixin {
+	/**
+	 * Inject into rendering after all other BERs have been rendered (and as such all BERs have populated the BufferBuilders)
+	 * and draw the buffers to the screen.
+	 * TODO: If FREX/Fabric Rendering API implements a callback for batched BER rendering, conditionally enable this
+	 *     mixin and use the callback if it exists.
+	 */
+	@Inject(method = "render(Lnet/minecraft/client/util/math/MatrixStack;FJZLnet/minecraft/client/render/Camera;Lnet/minecraft/client/render/GameRenderer;Lnet/minecraft/client/render/LightmapTextureManager;Lnet/minecraft/util/math/Matrix4f;)V",
+		at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/WorldRenderer;checkEmpty(Lnet/minecraft/client/util/math/MatrixStack;)V", ordinal = 0),
+		slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/entity/BlockEntityRenderDispatcher;render(Lnet/minecraft/block/entity/BlockEntity;FLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;)V"))
+	)
+	public void afterRenderBlockEntities(MatrixStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f, CallbackInfo ci) {
+		BakedBlockEntityRenderer.VertexBufferManager.INSTANCE.render(matrices, camera);
+	}
+
+	@Inject(method = "setWorld", at = @At("HEAD"))
+	public void onSetWorld(ClientWorld clientWorld, CallbackInfo ci) {
+		BakedBlockEntityRenderer.VertexBufferManager.INSTANCE.setWorld(clientWorld);
+	}
+
+}

--- a/src/main/resources/glowcase.mixins.json
+++ b/src/main/resources/glowcase.mixins.json
@@ -6,6 +6,7 @@
     "block.EntityShapeContextAccessor"
   ],
   "client": [
+    "client.render.ber.WorldRendererMixin",
     "client.render.entity.EntityRenderDispatcherAccessor"
   ],
   "injectors": {


### PR DESCRIPTION
This PR significantly improves performance of Text Block rendering by baking the rendered vertices and storing them on the GPU using Vertex Buffer Objects, one per render layer per render region (currently a 2x2 chunk region). I'll probably extract this into an external dependency at some point as others might want to use it, but for now it works as part of Glowcase. It could probably be optimised a fair amount as well, for example by reusing VertexBuffers.

Similarly to https://github.com/Earthcomputer/PolyDungeons/pull/12 it is incompatible with Canvas, but hopefully an appropriate hook can be made in FREX/Fabric Rendering API to allow this to work with any renderer.