### PR TITLE
Fix Z-fighting again, fix shadow being visible through walls

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/TextBlockEntityRenderer.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/TextBlockEntityRenderer.java
@@ -62,16 +62,17 @@ public class TextBlockEntityRenderer extends BakedBlockEntityRenderer<TextBlockE
 			matrices.translate(dX, 0, 0);
 
 			if (blockEntity.shadowType == TextBlockEntity.ShadowType.PLATE && width > 0) {
-				matrices.translate(0, 0, -0.005D);
+				matrices.translate(0, 0, -0.025D);
 				drawFillRect(matrices, vertexConsumers, (int) width + 5, (i + 1) * 12 - 2, -5, i * 12 - 2, 0x44000000);
-				matrices.translate(0, 0, 0.005D);
+				matrices.translate(0, 0, 0.025D);
 			}
 
 			if (blockEntity.shadowType == TextBlockEntity.ShadowType.DROP) {
 				// Don't use the vanilla shadow rendering - it breaks when you try to use it in 3D
 				int shadowColor = 0x88000000;
-				matrices.translate(0, 0, -0.005D);
-				textRenderer.draw(blockEntity.lines.get(i), 1, (i * 12) + 1, shadowColor, false, matrices.peek().getModel(), vertexConsumers, true, 0, 15728880);
+				matrices.translate(0, 0, -0.025D);
+				textRenderer.draw(blockEntity.lines.get(i), 1, (i * 12) + 1, shadowColor, false, matrices.peek().getModel(), vertexConsumers, false, 0, 15728880);
+				matrices.translate(0, 0, 0.025D);
 			}
 
 			textRenderer.draw(blockEntity.lines.get(i), 0, i * 12, blockEntity.color, false, matrices.peek().getModel(), vertexConsumers, false, 0, 15728880);


### PR DESCRIPTION
As it turns out, seeThrough doesn't make it translucent, it makes it visible through walls! It also seems that rendering order doesn't matter, Z-fighting will happen anyway - at least for this type of batched/baked rendering.