### PR TITLE
Update baked rendering for 1.17, use WorldRenderEvents

### DIFF
--- a/src/main/java/dev/hephaestus/glowcase/GlowcaseClient.java
+++ b/src/main/java/dev/hephaestus/glowcase/GlowcaseClient.java
@@ -1,7 +1,6 @@
 package dev.hephaestus.glowcase;
 
-import dev.hephaestus.glowcase.client.gui.screen.ingame.HyperlinkBlockEditScreen;
-import dev.hephaestus.glowcase.client.gui.screen.ingame.TextBlockEditScreen;
+import dev.hephaestus.glowcase.client.render.block.entity.BakedBlockEntityRenderer;
 import dev.hephaestus.glowcase.client.render.block.entity.HyperlinkBlockEntityRenderer;
 import dev.hephaestus.glowcase.client.render.block.entity.ItemDisplayBlockEntityRenderer;
 import dev.hephaestus.glowcase.client.render.block.entity.TextBlockEntityRenderer;
@@ -9,7 +8,7 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.rendereregistry.v1.BlockEntityRendererRegistry;
-import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 
 @Environment(EnvType.CLIENT)
 public class GlowcaseClient implements ClientModInitializer {
@@ -18,5 +17,8 @@ public class GlowcaseClient implements ClientModInitializer {
 		BlockEntityRendererRegistry.INSTANCE.register(Glowcase.TEXT_BLOCK_ENTITY, TextBlockEntityRenderer::new);
 		BlockEntityRendererRegistry.INSTANCE.register(Glowcase.HYPERLINK_BLOCK_ENTITY, HyperlinkBlockEntityRenderer::new);
 		BlockEntityRendererRegistry.INSTANCE.register(Glowcase.ITEM_DISPLAY_BLOCK_ENTITY, ItemDisplayBlockEntityRenderer::new);
+
+		WorldRenderEvents.AFTER_ENTITIES.register(ctx ->
+			BakedBlockEntityRenderer.VertexBufferManager.INSTANCE.render(ctx.matrixStack(), ctx.projectionMatrix(), ctx.camera()));
 	}
 }

--- a/src/main/java/dev/hephaestus/glowcase/block/GlowcaseBlock.java
+++ b/src/main/java/dev/hephaestus/glowcase/block/GlowcaseBlock.java
@@ -25,7 +25,7 @@ public class GlowcaseBlock extends Block {
 
 	@Override
 	public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
-		if (((EntityShapeContextAccessor) context).heldItem() instanceof GlowcaseItem && context != ShapeContext.absent()) {
+		if (((EntityShapeContextAccessor) context).heldItem().getItem() instanceof GlowcaseItem && context != ShapeContext.absent()) {
 			return VoxelShapes.fullCube();
 		} else {
 			return PSEUDO_EMPTY;

--- a/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/TextBlockEntityRenderer.java
+++ b/src/main/java/dev/hephaestus/glowcase/client/render/block/entity/TextBlockEntityRenderer.java
@@ -1,10 +1,9 @@
 package dev.hephaestus.glowcase.client.render.block.entity;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import dev.hephaestus.glowcase.block.entity.TextBlockEntity;
+import dev.hephaestus.glowcase.mixin.client.render.ber.RenderPhaseAccessor;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.render.*;
-import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.state.property.Properties;
@@ -50,14 +49,12 @@ public class TextBlockEntityRenderer extends BakedBlockEntityRenderer<TextBlockE
 
 		matrices.translate(0,  -((blockEntity.lines.size() - 0.25) * 12) / 2D, 0D);
 		for (int i = 0; i < blockEntity.lines.size(); ++i) {
-			double dX = 0;
-
 			double width = textRenderer.getWidth(blockEntity.lines.get(i));
-			switch (blockEntity.textAlignment) {
-				case LEFT:      dX = -maxLength / 2D;                           break;
-				case CENTER:    dX = (maxLength - width) / 2D - maxLength / 2D; break;
-				case RIGHT:     dX = maxLength - width - maxLength / 2D;        break;
-			}
+			double dX = switch (blockEntity.textAlignment) {
+				case LEFT -> -maxLength / 2D;
+				case CENTER -> (maxLength - width) / 2D - maxLength / 2D;
+				case RIGHT -> maxLength - width - maxLength / 2D;
+			};
 
 			matrices.push();
 			matrices.translate(dX, 0, 0);
@@ -87,13 +84,10 @@ public class TextBlockEntityRenderer extends BakedBlockEntityRenderer<TextBlockE
 	// Use a custom render layer to render the text plate - mimics DrawableHelper's RenderSystem calls
 	// TODO: This causes issues with transparency - not sure if these can be fixed?
 	private final RenderLayer plateRenderLayer = RenderLayer.of("glowcase_text_plate", VertexFormats.POSITION_COLOR,
-		7, 256, true, true, RenderLayer.MultiPhaseParameters.builder()
-			// Use no texture
-			.texture(new RenderPhase.Texture())
-			.transparency(new RenderPhase.Transparency("glowcase_defaultblendfunc", () -> {
-				RenderSystem.enableBlend();
-				RenderSystem.defaultBlendFunc();
-			}, RenderSystem::disableBlend))
+		VertexFormat.DrawMode.QUADS, 256, true, true, RenderLayer.MultiPhaseParameters.builder()
+			.texture(RenderPhaseAccessor.getNO_TEXTURE())
+			.transparency(RenderPhaseAccessor.getTRANSLUCENT_TRANSPARENCY())
+			.shader(RenderPhaseAccessor.getCOLOR_SHADER())
 			.build(false));
 
 	@SuppressWarnings("SameParameterValue")

--- a/src/main/java/dev/hephaestus/glowcase/mixin/block/EntityShapeContextAccessor.java
+++ b/src/main/java/dev/hephaestus/glowcase/mixin/block/EntityShapeContextAccessor.java
@@ -1,12 +1,12 @@
 package dev.hephaestus.glowcase.mixin.block;
 
 import net.minecraft.block.EntityShapeContext;
-import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(EntityShapeContext.class)
 public interface EntityShapeContextAccessor {
 	@Accessor("heldItem")
-	Item heldItem();
+	ItemStack heldItem();
 }

--- a/src/main/java/dev/hephaestus/glowcase/mixin/client/render/ber/RenderPhaseAccessor.java
+++ b/src/main/java/dev/hephaestus/glowcase/mixin/client/render/ber/RenderPhaseAccessor.java
@@ -1,0 +1,26 @@
+package dev.hephaestus.glowcase.mixin.client.render.ber;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.render.RenderPhase;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Environment(EnvType.CLIENT)
+@Mixin(RenderPhase.class)
+public interface RenderPhaseAccessor {
+	@Accessor
+	static RenderPhase.TextureBase getNO_TEXTURE() {
+		throw new RuntimeException("Mixin not applied");
+	}
+
+	@Accessor
+	static RenderPhase.Transparency getTRANSLUCENT_TRANSPARENCY() {
+		throw new RuntimeException("Mixin not applied");
+	}
+
+	@Accessor
+	static RenderPhase.Shader getCOLOR_SHADER() {
+		throw new RuntimeException("Mixin not applied");
+	}
+}

--- a/src/main/java/dev/hephaestus/glowcase/mixin/client/render/ber/WorldRendererMixin.java
+++ b/src/main/java/dev/hephaestus/glowcase/mixin/client/render/ber/WorldRendererMixin.java
@@ -3,39 +3,18 @@ package dev.hephaestus.glowcase.mixin.client.render.ber;
 import dev.hephaestus.glowcase.client.render.block.entity.BakedBlockEntityRenderer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.render.Camera;
-import net.minecraft.client.render.GameRenderer;
-import net.minecraft.client.render.LightmapTextureManager;
 import net.minecraft.client.render.WorldRenderer;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.util.math.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Environment(EnvType.CLIENT)
 @Mixin(WorldRenderer.class)
 public class WorldRendererMixin {
-	/**
-	 * Inject into rendering after all other BERs have been rendered (and as such all BERs have populated the BufferBuilders)
-	 * and draw the buffers to the screen.
-	 * TODO: If FREX/Fabric Rendering API implements a callback for batched BER rendering, conditionally enable this
-	 *     mixin and use the callback if it exists.
-	 */
-	@Inject(method = "render(Lnet/minecraft/client/util/math/MatrixStack;FJZLnet/minecraft/client/render/Camera;Lnet/minecraft/client/render/GameRenderer;Lnet/minecraft/client/render/LightmapTextureManager;Lnet/minecraft/util/math/Matrix4f;)V",
-		at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/WorldRenderer;checkEmpty(Lnet/minecraft/client/util/math/MatrixStack;)V", ordinal = 0),
-		slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/entity/BlockEntityRenderDispatcher;render(Lnet/minecraft/block/entity/BlockEntity;FLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;)V"))
-	)
-	public void afterRenderBlockEntities(MatrixStack matrices, float tickDelta, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightmapTextureManager lightmapTextureManager, Matrix4f matrix4f, CallbackInfo ci) {
-		BakedBlockEntityRenderer.VertexBufferManager.INSTANCE.render(matrices, camera);
-	}
-
 	@Inject(method = "setWorld", at = @At("HEAD"))
 	public void onSetWorld(ClientWorld clientWorld, CallbackInfo ci) {
 		BakedBlockEntityRenderer.VertexBufferManager.INSTANCE.setWorld(clientWorld);
 	}
-
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,6 +22,7 @@
   ],
   "accessWidener": "glowcase.accesswidener",
   "depends": {
-    "fabricloader": ">=0.8.8+build.202"
+    "fabricloader": ">=0.8.8+build.202",
+    "fabric-rendering-v1": ">=1.5.0"
   }
 }

--- a/src/main/resources/glowcase.accesswidener
+++ b/src/main/resources/glowcase.accesswidener
@@ -1,2 +1,9 @@
 accessWidener	v1	named
 accessible method net/minecraft/client/util/SelectionManager moveCursorToEnd (Z)V
+
+accessible method net/minecraft/client/render/RenderLayer of (Ljava/lang/String;Lnet/minecraft/client/render/VertexFormat;Lnet/minecraft/client/render/VertexFormat$DrawMode;IZZLnet/minecraft/client/render/RenderLayer$MultiPhaseParameters;)Lnet/minecraft/client/render/RenderLayer$MultiPhase;
+accessible class  net/minecraft/client/render/RenderLayer$MultiPhaseParameters
+
+accessible class  net/minecraft/client/render/RenderPhase$TextureBase
+accessible class  net/minecraft/client/render/RenderPhase$Shader
+accessible class  net/minecraft/client/render/RenderPhase$Transparency

--- a/src/main/resources/glowcase.mixins.json
+++ b/src/main/resources/glowcase.mixins.json
@@ -6,6 +6,7 @@
     "block.EntityShapeContextAccessor"
   ],
   "client": [
+    "client.render.ber.RenderPhaseAccessor",
     "client.render.ber.WorldRendererMixin",
     "client.render.entity.EntityRenderDispatcherAccessor"
   ],


### PR DESCRIPTION
Using Fabric API's WorldRenderEvents improves compatibility with rendering mods like Canvas.
Also fixes EntityShapeContextAccessor to return ItemStack, and uses a HashSet to store invalid render regions for improved performance.